### PR TITLE
docs: tighten FF1/DP-1 first-run guidance

### DIFF
--- a/docs/api-reference/auth-rate-limits.md
+++ b/docs/api-reference/auth-rate-limits.md
@@ -1,3 +1,9 @@
 # Auth & Rate-Limits
 
-Coming soon
+This path is kept for link continuity.
+
+Current authentication and operational integration guidance is covered in the active protocol and feed pages.
+
+## Next step
+
+Open [DP-1: Start Here (Integrators)](../dp1-protocol/overview.md).

--- a/docs/api-reference/cli.md
+++ b/docs/api-reference/cli.md
@@ -1,165 +1,117 @@
-### Overview
+# FF1 CLI: Start Here
 
-FF1 CLI builds and validates DP‑1 (Display Protocol 1) playlists from NFT data using either natural language (AI‑orchestrated function calling) or deterministic parameters. For the DP‑1 spec, see [DP-1 Specification](https://github.com/display-protocol/dp1).
+FF1 CLI is a command-line tool that builds DP-1 playlists from NFT and feed data.
 
-**Key characteristics:**
+Use it when you want the shortest path from a prompt to visible playback on an FF1 art computer.
 
-- Deterministic by design: tool outputs are validated against DP‑1 before send.
+- What this is: the primary command workflow for building and sending playlists.
+- Why use it: fastest route from prompt to play on FF1 reference hardware.
+- What to do next: run the first success flow below.
 
-- Optional Ed25519 signing with canonical JSON via `dp1-js`.
+## Version note
 
-### Install
+Examples in this page align with current FF1 CLI behavior, which builds playlists with `dpVersion: 1.0.0`.
 
-Use the Node.js workflow provided by the project:
+The canonical DP-1 specification is currently `v1.1.0` and adds multi-signature support via `signatures`.
 
-```bash
-npm install
-```
+FF1 CLI currently emits `dpVersion: 1.0.0` with legacy top-level `signature` behavior in its default playlist flow.
 
-Initialize and validate configuration:
+Use your toolchain's supported version and verify against the canonical spec before production use.
 
-```bash
-npm run dev -- config init
-npm run dev -- config validate
-```
+## First success in minutes
 
-Optional build for production:
+This path uses the canonical commands from `feral-file/ff1-cli`.
 
 ```bash
-npm run build
-node dist/index.js chat
+# 1) Install (shortest path)
+npm i -g ff1-cli
+
+# 2) Initialize and verify config
+ff1 config init
+ff1 config validate
+
+# 3) Build one playlist
+ff1 chat "Get tokens 1,2,3 from Ethereum contract 0xabc" -o playlist.json
+
+# 4) Validate playlist
+ff1 validate playlist.json
+
+# 5) If your device is configured, play on FF1
+ff1 send playlist.json -d "Living Room Display"
 ```
 
-### Quick start
+You are successful when `playlist.json` validates and, if a device is available, the playlist plays on FF1.
 
-Natural language (AI‑orchestrated):
+## Install options
+
+### Primary
 
 ```bash
-npm run dev chat
-npm run dev -- chat "Get tokens 1,2,3 from Ethereum contract 0xabc" -o playlist.json
+npm i -g ff1-cli
 ```
 
-Deterministic (no AI):
+### Alternate: prebuilt binary installer
 
 ```bash
-npm run dev -- build examples/params-example.json -o playlist.json
+curl -fsSL https://feralfile.com/ff1-cli-install | bash
 ```
 
-### Commands and flags
-
-- `chat [content]` – AI‑driven natural language playlists
-  - Options: `-o, --output <file>`, `-m, --model <name>`, `-v, --verbose`
-- `build [params.json]` – Deterministic build from JSON file or stdin
-  - Options: `-o, --output <file>`, `-v, --verbose`
-- `validate <file>` / `verify <file>` – Validate a DP‑1 playlist file
-- `sign <file>` – Sign playlist with Ed25519
-  - Options: `-k, --key <base64>`, `-o, --output <file>`
-- `send <file>` – Send playlist to an FF1 device
-  - Options: `-d, --device <name>`, `--skip-verify`
-- `config <init|show|validate>` – Manage configuration
-
-Models are configured in `config.json` and can be switched at runtime via `--model`.
-
-### Examples
-
-Setup:
+### Alternate: one-off with npx
 
 ```bash
-npm install
-npm run dev -- config init
-npm run dev -- config validate
+npx ff1-cli config init
+npx ff1-cli chat
 ```
 
-Natural language:
+## Commands by job
+
+- Build playlist from natural language: `ff1 chat [content]`
+- Build playlist from deterministic params: `ff1 build [params.json]`
+- Validate a playlist file or URL: `ff1 validate <file-or-url>`
+- Sign a playlist: `ff1 sign <file>`
+- Send a playlist to FF1: `ff1 send <file-or-url>`
+- Play a direct media URL: `ff1 play <url>`
+- Publish to feed server: `ff1 publish <file>`
+- Configure and inspect setup: `ff1 config <init|show|validate>`
+
+## Copy-paste examples
+
+### Build from natural language
 
 ```bash
-# Interactive chat
-npm run dev chat
-
-# One‑shot requests
-npm run dev -- chat "Get tokens 1,2,3 from Ethereum contract 0xabc" -o playlist.json
-npm run dev -- chat "Get token 42 from Tezos contract KT1abc"
-npm run dev -- chat "Get 3 items from Social Codes and 2 from 0xdef" -v
-
-# Switch model
-npm run dev -- chat "your request" --model grok
-npm run dev -- chat "your request" --model chatgpt
-npm run dev -- chat "your request" --model gemini
+ff1 chat "Get token 42 from Tezos contract KT1abc" -o playlist.json
 ```
 
-Deterministic build (no AI):
+### Build without AI
 
 ```bash
-# From file
-npm run dev -- build examples/params-example.json -o playlist.json
-
-# From stdin
-cat examples/params-example.json | npm run dev -- build -o playlist.json
+ff1 build ./params.json -o playlist.json
 ```
 
-AI‑orchestrated deterministic flow (prompts):
+### Validate, then play
 
 ```bash
-# Show tool‑call progress and validation
-npm run dev -- chat "Build a playlist of my Tezos works from address tz1... plus 3 from Social Codes" -v -o playlist.json
-
-# Switch model if desired
-npm run dev -- chat "Build playlist from Ethereum address 0x... and 2 from Social Codes" --model chatgpt -v
+ff1 validate playlist.json
+ff1 send playlist.json -d "Living Room Display"
 ```
 
-One‑shot complex prompt:
+## Common failure points
 
-```bash
-# Combine sources, shuffle, set per‑item duration, and send to a device
-npm run dev -- chat "Get tokens 1,2 from contract 0xabc and token 42 from KT1xyz; shuffle; 6 seconds each; send to 'Living Room Display'." -o playlist.json -v
-```
+- `config validate` fails: run `ff1 config show`, fix API keys and model settings, then re-run validation.
+- `chat` fails with provider/auth errors: confirm provider API key env vars or `config.json` values.
+- `send` cannot find device: check device host/name in config and make sure FF1 is reachable on your network.
+- `send` version error: FF1 OS is below minimum supported version for that command; update FF1 OS and retry.
+- Signature expectations differ by toolchain: many current CLI flows produce legacy top-level `signature` instead of `signatures[]`.
 
-Validate / sign / send:
+## Deeper references
 
-```bash
-# Validate playlist
-npm run dev -- validate playlist.json
+- Full usage and workflow docs: <https://github.com/feral-file/ff1-cli/blob/main/docs/README.md>
+- Configuration reference: <https://github.com/feral-file/ff1-cli/blob/main/docs/CONFIGURATION.md>
+- Function-calling details: <https://github.com/feral-file/ff1-cli/blob/main/docs/FUNCTION_CALLING.md>
+- More examples: <https://github.com/feral-file/ff1-cli/blob/main/docs/EXAMPLES.md>
+- DP-1 protocol spec: <https://github.com/display-protocol/dp1/blob/main/docs/spec.md>
+- DP-1 validator behavior: <https://github.com/display-protocol/dp1-validator>
 
-# Sign playlist
-npm run dev -- sign playlist.json -o signed.json
+## Next step
 
-# Send to device (verifies by default)
-npm run dev -- send playlist.json -d "Living Room Display"
-```
-
-### Troubleshooting
-
-Configuration and diagnostics:
-
-```bash
-# Show current configuration
-npm run dev -- config show
-
-# Reinitialize config
-npm run dev -- config init
-
-# Validate config and surface actionable errors
-npm run dev -- config validate
-```
-
-Notes and constraints:
-- Max 20 items total across all requirements
-- Duration per item defaults to 10s (configurable)
-- Device selection: omit `-d` to use the first configured device, or pass exact `--device <name>`
-
-### Configuration reference
-
-See [Configuration Guide](https://github.com/feral-file/ff1-cli/blob/main/docs/CONFIGURATION.md) for all fields, environment variables, feed settings, and FF1 device selection rules. Minimal `config.json` and environment variable helpers are provided there.
-
-### Function calling architecture
-
-For how the model orchestrates tool calls, schemas, and the deterministic pipeline, see [Function Calling Details](https://github.com/feral-file/ff1-cli/blob/main/docs/FUNCTION_CALLING.md). In short: parse intent → call tools to fetch/build → verify DP‑1 → optionally sign → optionally send.
-
-### See also
-
-- [Command API reference](../api-reference/command-api.md)
-- [General CLI README](https://github.com/feral-file/ff1-cli/blob/main/docs/README.md)
-- [Examples](https://github.com/feral-file/ff1-cli/blob/main/docs/EXAMPLES.md)
-- [Configuration](https://github.com/feral-file/ff1-cli/blob/main/docs/CONFIGURATION.md)
-- [Function calling details](https://github.com/feral-file/ff1-cli/blob/main/docs/FUNCTION_CALLING.md)
-- [DP‑1 specification](https://github.com/display-protocol/dp1)
+Run the FF1 bridge flow: [From valid DP-1 playlist to FF1 playback](../dp1-protocol/ff1-integration.md).

--- a/docs/dp1-protocol/feed-server.md
+++ b/docs/dp1-protocol/feed-server.md
@@ -1,397 +1,54 @@
-# DP-1 Feed Server
+# Hosted Feed (Feral File)
 
-*A comprehensive guide to Feral File's hosted DP-1 Feed Server – your central registry for playlist storage, validation, and distribution in the Display Protocol ecosystem*
+This page covers the hosted DP-1 feed operated by Feral File.
 
----
+Use it when you want a managed endpoint instead of running your own feed server.
 
-## Overview
+- What this is: hosted feed usage guidance for Feral File-managed infrastructure.
+- Why use it: quickest managed path to publish and retrieve playlists.
+- What to do next: validate a payload, then POST to the hosted endpoint.
 
-Feral's DP-1 Feed Server is the production backbone for our digital art playlists, running at [feed.feralfile.com](https://feed.feralfile.com). It bridges content creation (think AI commands or manual curation) and playback on FF1 devices or other clients, all while enforcing DP-1 standards for smooth, tamper-proof delivery.
+## What this is
 
-This guide zooms in on our hosted instance—endpoints, auth, and workflows tailored to Feral exhibitions. For the open-source implementation details (like building your own), check out the [dp1-feed repo](https://github.com/display-protocol/dp1-feed).
+The hosted feed accepts DP-1 playlists, validates payloads, and serves playlist data over HTTP APIs.
 
-**Key Functions:**
+Base URL:
 
-- **Playlist Registry**: Stores and indexes DP-1 compliant playlists with unique IDs
-- **Schema Validation**: Checks everything against DP-1 specs before saving
-- **Cryptographic Security**: Signs playlists with Ed25519 for authenticity
-- **Global Distribution**: Low-latency access via Cloudflare's edge network
-- **API Gateway**: RESTful endpoints for CRUD on playlists
+`https://feed.feralfile.com/api/v1`
 
-### Role in the Feral Ecosystem
+## Hosted vs self-hosted
 
-```mermaid
-graph TB
-    subgraph "Content Creation"
-        A[AI Command API]
-        B[Manual Curation Tools]
-        C[Third-party Integrations]
-    end
-    
-    subgraph "Feral Feed Server"
-        D[Hosted at feed.feralfile.com]
-        E[Schema Validator]
-        F[Cryptographic Signer]
-        G[Cloudflare KV Storage]
-    end
-    
-    subgraph "Content Consumption"
-        H[FF1 Devices]
-        I[Web Players]
-        J[Mobile Apps]
-        K[Third-party Displays]
-    end
-    
-    A --> D
-    B --> D
-    C --> D
-    D --> E
-    D --> F
-    D --> G
-    D --> H
-    D --> I
-    D --> J
-    D --> K
-    
-    style D fill:#e1f5fe
-    style G fill:#f3e5f5
-```
+- Hosted (this page): managed endpoint at `feed.feralfile.com`
+- Self-hosted: run your own open-source reference feed operator (`display-protocol/dp1-feed`) in your infrastructure
 
----
+If you need full control, use [Run your own Feed Server](self-hosted-feed.md).
 
-## Technical Architecture
+## Minimal hosted flow
 
-Our setup leverages edge-optimized tech for speed and scale—built on [Hono](https://hono.dev/) in Cloudflare Workers, with KV for storage. (Dive deeper into the stack in the [dp1-feed repo](https://github.com/display-protocol/dp1-feed) if you're forking this.)
+1. Build or prepare a valid DP-1 playlist.
+2. Validate first with [Validator Quickstart](validator.md).
+3. POST to hosted feed.
+4. Retrieve by ID or slug.
 
-### System Architecture
-
-```mermaid
-graph TB
-    subgraph "Client Layer"
-        A[Command API]
-        B[Mobile Apps]
-        C[Web Clients]
-        D[Display Devices]
-    end
-    
-    subgraph "Edge Network (200+ Locations)"
-        E[Cloudflare Workers]
-        F[Edge Cache]
-    end
-    
-    subgraph "Feed Server Application"
-        G[Hono Router]
-        H[Authentication Middleware]
-        I[Validation Engine]
-        J[Signature Service]
-        N[Message Queue]
-    end
-    
-    subgraph "Storage Layer"
-        K[Cloudflare KV]
-        L[Playlist Index]
-        M[Metadata Store]
-    end
-    
-    A --> E
-    B --> E
-    C --> E
-    D --> E
-    E --> F
-    E --> G
-    G --> H
-    H --> I
-    I --> J
-    J --> N
-    N --> K
-    K --> L
-    K --> M
-    
-    style G fill:#e8f5e8
-    style K fill:#fff3e0
-```
-
-### Data Flow
-
-1. **Playlist Submission**: POST to `/playlists` with your payload
-2. **Authentication**: We check your API key
-3. **Schema Validation**: Runs against DP-1 rules
-4. **Cryptographic Signing**: Adds an Ed25519 signature
-5. **Immediate Response**: You get the signed playlist back right away
-6. **Asynchronous Persistence**: Background queue saves to KV *(experimental—keeps things snappy)*
-7. **Global Distribution**: Edges cache it for fast fetches worldwide
-8. **Retrieval**: GET by ID or slug
-
-**Performance Note:** That async queue? It's our trick for handling big playlists without blocking—players start rendering instantly.
-
----
-
-## API Reference
-
-Base URL: `https://feed.feralfile.com/api/v1`
-
-All endpoints return JSON and follow HTTP norms. Write ops need auth; reads are public.
-
-### Authentication
-
-Feral API keys are issued via the [Command API](../api-reference/command-api.md) for seamless exhibition workflows. Keys respect our [rate limits](../api-reference/auth-rate-limits.md)—fair use for exhibitions. Slap 'em in the `Authorization` header:
+Example POST:
 
 ```bash
 curl -H "Authorization: Bearer your-api-key-here" \
-     -H "Content-Type: application/json" \
-     -X POST https://feed.feralfile.com/api/v1/playlists \
-     -d @playlist.json
+  -H "Content-Type: application/json" \
+  -X POST https://feed.feralfile.com/api/v1/playlists \
+  -d @playlist.json
 ```
 
-### Endpoints
+## API reference source
 
-#### Create Playlist
+- Canonical feed server OpenAPI: <https://github.com/display-protocol/dp1-feed/blob/main/openapi.yaml>
 
-**POST** `/playlists`
+## Notes
 
-Submit a new one—we validate, sign, and store it.
+- DP-1 is protocol-first and vendor-neutral; the hosted feed is one deployment option.
+- The open-source reference operator repo is not the same thing as Feral File's hosted production feed service.
+- If you need deployment details, storage model, or infrastructure tuning, use the open implementation docs in `display-protocol/dp1-feed`.
 
-**Request Body Example:**
-```json
-{
-  "dpVersion": "1.0.0",
-  "title": "Digital Art Showcase",
-  "defaults": {
-    "display": {
-      "scaling": "contain",
-      "background": "#000000",
-      "margin": 0
-    }
-  },
-  "items": [
-    {
-      "duration": 30,
-      "license": "open",
-      "source": "ipfs://cid",
-      "provenance": {
-        "type": "onChain",
-        "contract": {
-          "chain": "ethereum",
-          "standard": "ERC-721",
-          "address": "0x...",
-          "tokenId": "1"
-        }
-      }
-    }
-  ]
-}
-```
+## Next step
 
-**Response (201 Created):**
-```json
-{
-  "dpVersion": "1.0.0",
-  "id": "d241c5ad-a5e0-451e-89ec-de442811a869",
-  "slug": "digital-art-showcase-ds2",
-  "title": "Digital Art Showcase",
-  "created": "2025-08-11T08:49:14.454Z",
-  "defaults": {
-    "display": {
-      "scaling": "contain",
-      "background": "#000000",
-      "margin": 0
-    }
-  },
-  "items": [
-    {
-      "duration": 30,
-      "license": "open",
-      "source": "ipfs://cid",
-      "provenance": {
-        "type": "onChain",
-        "contract": {
-          "chain": "ethereum",
-          "standard": "ERC-721",
-          "address": "0x...",
-          "tokenId": "1"
-        }
-      },
-      "id": "732dc2a2-9597-4b91-b4b1-debc761f7fdd",
-      "created": "2025-09-04T09:23:25.526Z"
-    }
-  ],
-  "signature": "ed25519:0xabc..."
-}
-```
-
-**Errors:** 400 (bad format), 401 (auth fail, e.g., `{"error": "auth_error", "message": "Invalid API key"}`), 500 (server hiccup).
-
-#### Replace Playlist
-
-**PUT** `/playlists/{id}`
-
-Overwrite an existing one—same validation and signing.
-
-**Request Body:** Same as Create.
-
-**Response (200 OK):** Full updated playlist JSON.
-
-**Errors:** Same as above.
-
-#### Update Playlist
-
-**PATCH** `/playlists/{id}`
-
-Tweak fields like title or defaults—can't touch protected stuff like IDs.
-
-**Request Body Example:**
-```json
-{
-  "title": "Digital Art Showcase v2",
-  "defaults": {
-    "display": {
-      "scaling": "contain",
-      "background": "#000000",
-      "margin": 0
-    }
-  }
-}
-```
-
-**Response (200 OK):** Full updated playlist.
-
-**Errors:** 400 (invalid updates), plus the usual.
-
-#### Retrieve Playlist
-
-**GET** `/playlists/{id}`
-
-Grab by UUID or slug.
-
-**Response (200 OK):** Full playlist JSON.
-
-**Errors:** 400 (bad ID), 404 (not found), 500.
-
-#### List Playlists
-
-**GET** `/playlists`
-
-Paginated metadata list.
-
-**Query Params:**
-
-- `limit` (opt, default 100, max 100)
-- `cursor` (opt, for next page)
-- `sort` (opt, `asc`/`desc` by created, default `asc`)
-
-**Response (200 OK):**
-```json
-{
-  "playlists": [
-    {
-      "dpVersion": "1.0.0",
-      "id": "d241c5ad-a5e0-451e-89ec-de442811a869",
-      "slug": "digital-art-showcase-ds2",
-      "title": "Digital Art Showcase",
-      "created": "2025-08-11T08:49:14.454Z",
-      "items": [ /* abbreviated */ ],
-      "signature": "ed25519:0xabc..."
-    }
-  ],
-  "cursor": "next-cursor-here",
-  "hasMore": true
-}
-```
-
-#### Health Check
-
-**GET** `/health`
-
-Quick status ping.
-
-**Response (200 OK):**
-```json
-{
-  "status": "healthy",
-  "timestamp": "2025-09-08T07:36:30.348Z",
-  "version": "1.0.0",
-  "environment": "production",
-  "runtime": "cloudflare-worker"
-}
-```
-
----
-
-## Implementation Details
-
-### Playlist Validation
-
-We run full checks on every submit to keep things DP-1 compliant.
-
-#### Validation Rules (Feral Flavor)
-
-**Playlist Level:**
-
-- `dpVersion` must match supported versions (e.g., "1.0.0")
-- At least one item in `items`
-- Display defaults must be sane
-
-**Item Level:**
-
-- `duration` > 0 seconds
-- `license` in ["open", "token", "subscription"]
-- Provenance must link to valid chains if on-chain
-
-Errors come back detailed, like:
-```json
-{
-  "error": "validation_error",
-  "message": "items.0.source required; duration >=1; license invalid"
-}
-```
-
-### Cryptographic Signing
-
-Every playlist gets signed for trust—no tampering allowed.
-
-**How It Works:**
-
-1. Canonical JSON (per [RFC 8785](https://www.rfc-editor.org/rfc/rfc8785))
-2. SHA-256 hash
-3. Ed25519 sign with our private key
-4. Encode as `ed25519:<hex>`
-
-Verify on your end by stripping signature, hashing, and checking against our public key (from the repo).
-
-### Storage Architecture
-
-Cloudflare KV handles the heavy lifting—global, replicated, no TTLs for permanence.
-
-**Keys:** `playlist:{id}` or `playlist:{slug}` for full data; indexed by timestamp for lists.
-
----
-
-## Development & Deployment
-
-Want to run your own DP1 feed server? 
-
-→ **[Self-Hosting a Feed Server](self-hosted-feed.md)** - Complete setup guide with Docker and Node.js options
-
-For additional resources:
-
-- [dp1-feed repo](https://github.com/display-protocol/dp1-feed) - Official repository with documentation
-- [Feral File fork](https://github.com/feral-file/dp1-feed) - Feral-specific customizations
-
----
-
-## Conclusion
-
-Feral's Feed Server makes DP-1 feel effortless—create, validate, distribute, done. It's the glue for your exhibitions, keeping art flowing securely to FF1s and beyond.
-
-### Key Takeaways
-- **Hosted & Ready**: Plug into `feed.feralfile.com` today
-- **Secure by Default**: Signatures + validation = peace of mind
-- **Scales Globally**: Edge caching handles the load
-- **Open Roots**: Build on our public impls
-
-### Next Steps
-1. Grab an API key from [Command API](../api-reference/command-api.md)
-2. Test a playlist POST
-3. Check [Player Behavior](player-behavior.md) for FF1 rendering tips
-
-For protocol deep dives, head to [DP-1 spec](https://github.com/display-protocol/dp1/blob/main/docs/spec.md).
+If you want your own deployment, follow [Run your own Feed Server](self-hosted-feed.md).

--- a/docs/dp1-protocol/ff1-integration.md
+++ b/docs/dp1-protocol/ff1-integration.md
@@ -1,15 +1,42 @@
-# DP-1 with FF1 Integration
+# From DP-1 Playlist to FF1 Playback
 
-## Quickstart
-1. Generate playlist via [AI Commands](../llm-agents/quickstart.md).
-2. POST to [Feral Feed Server](feed-server.md).
-3. Assign to FF1 via [Command API](../api-reference/command-api.md).
+DP-1 is the open protocol.
 
-## Best Practices
-- Use `provenance` for NFT-gated exhibitions.
-- Set `duration` ≤ 600s for smooth looping.
-- Test with [Validator](https://github.com/display-protocol/dp1-validator).
+FF1 is Feral File's art computer and the reference hardware for playback.
 
-## Troubleshooting
-- Signature errors: Re-validate against public schemas.
-- Render issues: Check [Player Behavior](player-behavior.md) for FF1 quirks.
+This page is the shortest bridge from a valid DP-1 playlist to visible playback on FF1.
+
+Version note: this bridge accepts any playlist that validates for your toolchain. Current FF1 CLI examples in these docs emit `dpVersion: 1.0.0`; canonical DP-1 spec is `v1.1.0`.
+
+Validator quickstart in this docs path focuses on structure checks and legacy top-level signature verification.
+
+## Shortest path
+
+1. Validate your playlist: [Validator Quickstart](validator.md)
+2. Send playlist to FF1:
+
+```bash
+curl --request POST "http://$DEVICE_ID.local:1111/api/cast" \
+  --header "content-type:application/json" \
+  --data '{"command":"displayPlaylist","request":{"playlistUrl":"$PLAYLIST_URL","intent":{"action":"now_display"}}}'
+```
+
+Replace:
+
+- `$DEVICE_ID` with your FF1 device id
+- `$PLAYLIST_URL` with your hosted DP-1 playlist URL
+
+## If you prefer CLI
+
+Use [FF1 CLI: Start Here](../api-reference/cli.md) and end with `ff1 send`.
+
+## Common failure points
+
+- Device not reachable on local network.
+- Playlist URL is not publicly reachable by the device.
+- Playlist did not pass validation before send.
+- Signature model mismatch across tools: legacy `signature` vs spec `signatures[]` expectations.
+
+## Next step
+
+Tune playback behavior in [Player Behavior](player-behavior.md).

--- a/docs/dp1-protocol/overview.md
+++ b/docs/dp1-protocol/overview.md
@@ -1,33 +1,51 @@
-# DP-1 Protocol Overview
+# DP-1: Start Here (Integrators)
 
-## Feral File's Implementation
-DP-1 is an open protocol for blockchain-native digital art display, enabling interoperable playlists across devices. Feral File seeds this ecosystem with FF1 hardware as the reference implementation and hosts a production Feed Server at [feed.feralfile.com](https://feed.feralfile.com).
+DP-1 is an open, vendor-neutral protocol for signed digital art playlists.
 
-For the full vendor-neutral spec, see the [public DP-1 repo](https://github.com/display-protocol/dp1), including [design principles (raw)](https://github.com/display-protocol/dp1/blob/main/docs/spec.md).
+Use DP-1 when you want portable playback across compatible players, with validation and signature checks as the trust baseline.
 
-### Why DP-1 for Feral File
-The digital display landscape faces challenges like fragmented standards and data integrity—DP-1 fixes that with unified validation and verifiable authenticity. For us, it powers seamless exhibitions: token-gated art on FF1s, AI-generated playlists, and global distribution.
+- What this is: the protocol entry point for integrators.
+- Why use it: one playlist format that can be validated and played across compatible systems.
+- What to do next: validate one minimal playlist first.
 
-## Core Components
-Key DP-1 pieces in our ecosystem:
+## Version note
 
-- **Feed Server**: Our hosted registry [](https://feed.feralfile.com) stores, validates, and signs playlists. See [Feed Server](feed-server.md).
-- **Validator**: Ensures schema compliance and Ed25519 signatures. Use the open [DP-1 Validator](https://github.com/display-protocol/dp1-validator) CLI.
-- **Schema**: Defines playlists with metadata, items, and display rules. Dive into [schemas.md](schemas.md) or the [OpenAPI spec (raw)](https://github.com/display-protocol/dp1-feed/blob/main/openapi.yaml).
-- **Display Client**: FF1 renders these—optimized for provenance checks and OTA updates.
+Canonical DP-1 specification is currently `v1.1.0`.
 
-## Benefits of DP-1
-- **Interoperability**: Content flows to FF1s, web players, and beyond.
-- **Data Integrity**: Built-in validation prevents breaks.
-- **Scalability**: Easy to scale exhibitions with new sources.
-- **Trust**: On-chain provenance verifies NFTs.
-- **Flexibility**: Supports open/token/subscription licenses.
+In this first-run flow, some examples use `dpVersion: 1.0.0` for compatibility with current CLI/operator tooling in the ecosystem.
 
-## Key Feral Integrations
-- **Exhibitions**: Model artworks as DP-1 playlists for token-gated displays (see [Exhibition Structure](../exhibitions-n-archive/exhibition-structure.md)).
-- **AI Commands**: Generate playlists via natural language (see [Quickstart](../llm-agents/quickstart.md)).
-- **FF1 Devices**: Render with hardware tweaks (see [Player Behavior](player-behavior.md)).
+Treat the spec as authoritative and choose the version your toolchain supports.
 
-## Next Steps
-- [Schemas](schemas.md) for Feral examples.
-- Set up access to our [Feed Server](feed-server.md).
+Do not assume blanket end-to-end `1.1.0` parity across CLI, validator, and feed operator unless explicitly verified in those repos.
+
+## First success flow
+
+1. Validate one minimal playlist with the validator.
+2. Review the core object model (`playlist`, `items`, `display`, `provenance`).
+3. Publish or host the validated playlist.
+4. Play it on FF1 (reference hardware) or another compatible player.
+
+## Canonical references
+
+- DP-1 specification (authoritative, currently v1.1.0): <https://github.com/display-protocol/dp1/blob/main/docs/spec.md>
+- DP-1 repository: <https://github.com/display-protocol/dp1>
+- Feed server implementation (OpenAPI + server): <https://github.com/display-protocol/dp1-feed>
+- Validator implementation and behavior notes: <https://github.com/display-protocol/dp1-validator>
+
+## Fast links for this site
+
+- Validate first: [Validator Quickstart](validator.md)
+- Understand object model: [Schemas](schemas.md)
+- Hosted feed guidance (Feral File): [Hosted Feed](feed-server.md)
+- Run your own feed: [Self-Hosted Feed](self-hosted-feed.md)
+- Short FF1 bridge: [From DP-1 to FF1 playback](ff1-integration.md)
+
+## Notes on roles
+
+- **DP-1** is the protocol.
+- **FF1** is Feral File's art computer and reference hardware.
+- You can integrate DP-1 without FF1.
+
+## Next step
+
+Run [Validator Quickstart](validator.md) and validate one playlist.

--- a/docs/dp1-protocol/player-behavior.md
+++ b/docs/dp1-protocol/player-behavior.md
@@ -1,38 +1,31 @@
 # Player Behavior
 
-DP-1 players like FF1 interpret playlists via a standardized lifecycle. For core rules, see [DP-1 spec](https://github.com/display-protocol/dp1/blob/main/docs/spec.md).
+This page explains how players consume DP-1 playlists at runtime.
 
-## FF1-Specific Behavior
-FF1 (Feral's reference hardware) renders DP-1 content with these optimizations:
+- What this is: runtime behavior guidance for playback clients.
+- Why use it: helps debug validation, fetch, and playback issues.
+- What to do next: confirm your player behavior against the canonical DP-1 spec.
 
-### Render Hints
-- **Scaling/Margins**: Defaults to "fit" with 5% margins; overrides per item take precedence.
-- **Backgrounds**: Supports hex colors; falls back to black (#000) for unstyled items.
-- **Transitions**: 1s fade between items; disabled for "instant" license types (e.g., subscription previews needing quick loads).
+## Version and compatibility note
 
-### Asset Locators
-FF1 resolves sources via:
-- **URLs**: Direct fetch (e.g., HTTPS/IPFS); caches for OTA updates (see [FF1 OTA](../ff1/how-it-works/ota.md)).
-- **Provenance Checks**: Verifies on-chain token ownership before token-gated renders.
-- **Fallbacks**: If source fails, displays static thumbnail from `ref` (IPFS manifest).
+- Canonical DP-1 spec is currently `v1.1.0`.
+- Some adjacent tooling still centers `dpVersion: 1.0.0` payloads and legacy top-level `signature` behavior.
+- Do not assume blanket end-to-end `1.1.0` parity across CLI, validator, and feed operator unless explicitly verified in those repos.
 
-### Lifecycle
-1. Fetch playlist from Feed Server.
-2. Validate signature.
-3. Loop items indefinitely (or until interrupted, e.g., new playlist via OTA), respecting durations.
-4. Handle errors: Log to console; skip to next item.
-   - **Power Cycle?** FF1 retries fetches on boot; check logs via SSH for provenance fails.
+## Runtime sequence (player view)
 
-Example FF1 config in playlist:
-```json
-{
-  "defaults": {
-    "display": { "scaling": "fit", "margin": "5%" }
-  }
-}
-```
+1. Load playlist from URL or feed endpoint.
+2. Validate playlist structure for the toolchain version in use.
+3. Verify trust metadata (`signature` or `signatures`) according to implemented verifier capabilities.
+4. Render items in order with item/default display settings.
+5. On failure, surface a clear error and continue according to player policy.
 
-For QEMU testing, see [FF1 QEMU](../ff1/qemu/macOS.md).
+## FF1 as reference hardware
 
-.
+FF1 is Feral File's art computer and a reference hardware path for DP-1 playback.
 
+Use FF1 behavior as one implementation path, not as the protocol definition.
+
+## Next step
+
+Use the bridge flow: [From DP-1 playlist to FF1 playback](ff1-integration.md).

--- a/docs/dp1-protocol/schemas.md
+++ b/docs/dp1-protocol/schemas.md
@@ -1,45 +1,59 @@
 # DP-1 Schemas
 
-For authoritative definitions, refer to the [DP-1 JSON schemas](https://github.com/display-protocol/dp1/blob/main/docs/spec.md) and [Feed API spec](https://github.com/display-protocol/dp1-feed/blob/main/openapi.yaml) in the public repo.
+This page explains the DP-1 object model in plain language and links the canonical schema sources.
 
-## Feral File Examples
-Feral workflows often extend core schemas with exhibition metadata. Example for an FF1-bound artwork:
+## Version note
+
+Canonical DP-1 specification is currently `v1.1.0`.
+
+The minimal example on this page uses `dpVersion: 1.0.0` for compatibility with current FF1 CLI output in the first-run flow.
+
+For production behavior, follow the canonical spec version your toolchain supports.
+
+Ecosystem tooling is transitional. Do not assume full `v1.1.0` end-to-end parity across all adjacent repos unless explicitly verified there.
+
+## Canonical sources
+
+- DP-1 specification and schema rules: <https://github.com/display-protocol/dp1/blob/main/docs/spec.md>
+- Feed server OpenAPI (operator API): <https://github.com/display-protocol/dp1-feed/blob/main/openapi.yaml>
+
+## Object model at a glance
+
+- `playlist`
+  - Top-level container with `dpVersion`, identity fields, display defaults, and `items`.
+- `defaults`
+  - Optional baseline values inherited by items (for example display settings, license, duration).
+- `items[]`
+  - The ordered media entries a player can render.
+- `display`
+  - Rendering preferences such as scaling, background, and margin.
+- `provenance`
+  - Optional source-of-truth metadata (for example on-chain contract context).
+- `signature` or `signatures`
+  - Integrity and trust metadata defined by the DP-1 spec version in use.
+
+## Minimal playlist shape
 
 ```json
 {
   "dpVersion": "1.0.0",
-  "id": "feral-exhibit-001",
-  "slug": "generative-sunset",
-  "title": "Generative Sunset",
-  "created": "2025-09-13T00:00:00Z",
-  "defaults": {
-    "display": { "scaling": "fit", "background": "#000" }
-  },
+  "id": "385f79b6-a45f-4c1c-8080-e93a192adccc",
+  "title": "Minimal DP-1 Playlist",
+  "created": "2025-10-17T07:02:03Z",
   "items": [
     {
-      "id": "item-001",
-      "slug": "sunset-loop",
-      "source": "https://cdn.feralfile.com/art/sunset.html",
-      "duration": 300,
-      "license": "token",
-      "ref": "ipfs://manifest-for-exhibition",  // Feral extension for token metadata
-      "provenance": {
-        "type": "onChain",
-        "contract": { "chain": "evm", "standard": "erc721", "address": "0x...", "tokenId": "123" }
-      }
+      "id": "item-1",
+      "title": "Example Item",
+      "source": "https://example.com/artwork.html",
+      "duration": 30,
+      "license": "open"
     }
-  ],
-  "signature": "ed25519:<hex>"
+  ]
 }
 ```
 
-## Quick Validation
-Use the open-source [DP-1 Validator](https://github.com/display-protocol/dp1-validator) to check your playlist:
-```bash
-./dp1-validator playlist --playlist "https://your-url/playlist.json" --pubkey "your-pubkey-hex"
-```
-It verifies signatures, schemas, and assets—essential for Feral submissions.
+Use this as a shape reference only. For authoritative field behavior and version rules, use the canonical spec.
 
-Validate with the open [DP-1 Validator](https://github.com/display-protocol/dp1-validator). For Feral-specific validation in exhibitions, see [Token Metadata](../exhibitions-n-archive/token-metadata.md).
+## Next step
 
-See also: Full field list in the [DP-1 spec](https://github.com/display-protocol/dp1/blob/main/docs/spec.md).
+Run [Validator Quickstart](validator.md) on your own payload.

--- a/docs/dp1-protocol/self-hosted-feed.md
+++ b/docs/dp1-protocol/self-hosted-feed.md
@@ -1,244 +1,71 @@
-# Self-Hosting a DP-1 Feed
-This guide walks you through setting up a DP-1 feed server so you can publish your own playlists for [FF1](../ff1/index.md).
+# Run Your Own Feed Server
 
-> Goal: run a feed on http://localhost:8787, protect write endpoints with API_SECRET, and server-sign playlists with an Ed25519 private key.
+This page is for running your own DP-1 feed operator using the open-source reference implementation.
 
-This feed server runs locally and signs playlists with your Ed25519 key, giving artists full control over how works are published and verified.
+- What this is: a practical operator path for self-hosted DP-1 feeds.
+- Why use it: full control over deployment, auth secrets, and signing keys.
+- What to do next: run a local operator and complete one create/fetch cycle.
 
-## 0. Prerequisites
+## Operator source of truth
+
+- Reference operator repo: <https://github.com/display-protocol/dp1-feed>
+- Canonical OpenAPI: <https://github.com/display-protocol/dp1-feed/blob/main/openapi.yaml>
+
+This page covers operator usage only. It is separate from Feral File's hosted production feed service.
+
+## Version and compatibility note
+
+- Canonical DP-1 protocol spec is currently `v1.1.0`: <https://github.com/display-protocol/dp1/blob/main/docs/spec.md>
+- Current operator examples are often centered on `dpVersion: 1.0.0`.
+- Treat those examples as practical implementation baselines, not blanket ecosystem parity claims.
+
+## Quick local run (Node + Docker)
+
+Prerequisites:
 
 - Node.js 22+
-- Git
-- Docker Desktop (recommended, for dependencies etcd + NATS JetStream)
-
-```bash
-node -v
-docker -v
-```
-
-Optional: Cloudflare Workers account if you want to deploy publicly.
-
-## 1. Clone and install
+- Docker + Docker Compose
 
 ```bash
 git clone https://github.com/display-protocol/dp1-feed.git
 cd dp1-feed
 npm install
-```
-
-> Most users should clone. Fork only if you plan to modify and publish your version
-
-## 2. Choose Your Setup Method
-
-You can run the DP1 feed server in two ways:
-
-### 🐳 **Method A: Full Docker Setup (Recommended)**
-Everything runs in Docker - dependencies and server. No `.env` file needed.
-
-### **Method B: Manual Node.js Development**  
-Server runs directly with Node.js. Requires `.env` setup.
-Run dependencies (etcd and NATS) using Docker (recommended), or set them up manually if you prefer.
-
----
-
-## Method A: Full Docker Setup
-
-### Run Everything with Docker
-```bash
-# Start all services (etcd, NATS, and dp1-feed server)
 docker compose up -d
-
-# → Server runs at http://localhost:8787
 ```
 
-**That's it!** Docker Compose includes pre-configured development secrets (`test-api-secret`, `test-ed25519-private-key`).
+The API is available at `http://localhost:8787`.
 
-> **Security note:** The provided secrets are for development only. **Never use these values in production.** Always generate strong, unique secrets for any publicly accessible deployment.  
-> See [Security note](#4-security-notes) below for details.
+## First trust-building cycle
 
-Health check:
+1. Health check
+
 ```bash
 curl http://localhost:8787/api/v1/health
-# {"status":"ok"}
 ```
 
-Skip to [Post Your First Playlist](#3-post-your-first-playlist) →
-
----
-
-## Method B: Manual Node.js Development
-
-### B.1. Start Dependencies Only
-
-Option a. Docker Compose. Start only etcd and NATS in Docker
-```bash
-docker compose up -d etcd nats
-```
-
-Option b. Manual setup
+2. Create playlist
 
 ```bash
-# Start etcd (terminal tab no.1)
-etcd --listen-client-urls http://0.0.0.0:2379 --advertise-client-urls http://localhost:2379
-
-# Start NATS with JetStream (terminal tab no.2)
-nats-server -js
-
-# Open terminal tab no.3 to run server
+curl -X POST http://localhost:8787/api/v1/playlists \
+  -H "Authorization: Bearer dev-api-secret" \
+  -H "Content-Type: application/json" \
+  -d @playlist.json
 ```
 
-### B.2. Configure Environment
-Create your development `.env` file:
+3. Fetch created playlist
 
 ```bash
-cp .env.sample .env
+curl http://localhost:8787/api/v1/playlists/<playlist-id-or-slug>
 ```
 
-Edit `.env` to set secrets. See [Security note](#4-security-notes) below for details.
+If you need to generate playlists quickly, use [FF1 CLI: Start Here](../api-reference/cli.md), then post the result to your operator.
 
-### B.3. Run Node.js Server
-```bash
-# Start dev server with live reload
-npm run node:dev
+## Security essentials
 
-# Or start production build
-npm run node:build
-npm run node:start
+- Keep `API_SECRET` and `ED25519_PRIVATE_KEY` out of source control.
+- Use generated secrets for any non-local deployment.
+- Rotate secrets when moving from local dev to shared environments.
 
-# → http://localhost:8787
-```
+## Next step
 
-Health check:
-```bash
-curl http://localhost:8787/api/v1/health
-# {"status":"ok"}
-```
-
-## 3. Post Your First Playlist
-
-Both methods use the same API. Use the development secret `test-api-secret`:
-
-```bash
-curl -H "Authorization: Bearer test-api-secret" \
-     -H "Content-Type: application/json" \
-     -X POST http://localhost:8787/api/v1/playlists \
-     -d @playlist.json
-```
-
-**Request Body Example:**
-```json
-{
-  "dpVersion": "1.0.0",
-  "title": "Digital Art Showcase",
-  "defaults": {
-    "display": {
-      "scaling": "contain",
-      "background": "#000000",
-      "margin": 0
-    }
-  },
-  "items": [
-    {
-      "duration": 30,
-      "license": "open",
-      "source": "ipfs://cid",
-      "provenance": {
-        "type": "onChain",
-        "contract": {
-          "chain": "evm",
-          "standard": "erc721",
-          "address": "0x...",
-          "tokenId": "1"
-        }
-      }
-    }
-  ]
-}
-```
-
-_For more endpoints and request/response details, visit the [API Reference](feed-server.md#api-reference)._
-
-### Generate Playlists from Your NFT Collection
-
-Instead of manually creating playlist JSON, you can use the **FF1 CLI** to automatically generate playlists from your existing NFT data:
-
-```bash
-# Generate playlist from specific NFT tokens
-ff1-cli$ npm run dev -- chat "Get tokens 1,2,3 from Ethereum contract 0xabc" -o playlist.json
-
-# Generate from your wallet address
-ff1-cli$ npm run dev -- chat "Build a playlist from my Ethereum address 0x..." -o playlist.json
-```
-
-Then post the generated playlist to your feed server:
-```bash
-curl -H "Authorization: Bearer test-api-secret" \
-     -H "Content-Type: application/json" \
-     -X POST http://localhost:8787/api/v1/playlists \
-     -d @playlist.json
-```
-
-→ **[Learn more about FF1 CLI](../api-reference/cli.md)** - Generate playlists from NFT data using AI or deterministic parameters
-
-## 4. Security Notes
-
-### Development vs Production Secrets
-
-**For local testing**: The provided placeholder values (`test-api-secret`, `test-ed25519-private-key`) are fine.
-
-**For production**: You MUST replace these with real secrets:
-
-### Generate Production Secrets
-
-**API_SECRET** - Protects write endpoints from unauthorized access:
-```bash
-openssl rand -hex 32
-# Use this entire string as your API_SECRET
-```
-
-**ED25519_PRIVATE_KEY** - Signs playlists cryptographically:
-```bash
-openssl genpkey -algorithm ED25519 -outform DER | xxd -p -c 256
-# Use this entire hex string as your ED25519_PRIVATE_KEY
-```
-
-### Security Best Practices
-
-- Generate fresh secrets.
-- Store them in a secrets manager (Vault, AWS Secrets Manager, Cloudflare secrets, etc.).
-- Never commit .env files with real keys to GitHub.
-
-## 5. Troubleshooting
-
-- **401 Unauthorized** → Missing or incorrect `Authorization: Bearer test-api-secret` header
-- **No signatures[]** → Server signing not configured. Check your setup (see [Security Notes](#4-security-notes))
-- **Port in use**: Another process may be running on port 8787. You can:
-    - Change the `PORT` variable, e.g. `PORT=8788 npm run dev`, then restart the server.
-    - Or stop the existing process using port 8787 (`npx kill-port 8787` or by killing it in your task manager).
-    - On Windows, you can check with `netstat -ano | findstr :8787` to identify and terminate the process.
-    - On macOS/Linux, use `lsof -i :8787` and `kill <PID>`.
-    - Verify Docker or other services aren’t conflicting with your chosen port.
-    - Restart your computer if you're unsure what's using the port.
-
----
-
-## 6. (Optional) Cloudflare Worker Deploy
-
-For public deployment, you can use [Cloudflare Workers](https://github.com/display-protocol/dp1-feed/blob/main/DEVELOPMENT.md#cloudflare-workers-development)
-
-```bash
-# Set secrets (use real values from Security Notes section)
-npm run worker:setup:secrets
-
-# Start with live reload
-npm run worker:dev
-
-# Deploy
-npm run worker:deploy
-```
-
-## What's Next?
-
-Once your feed server is running, try to:
-
-→ **[Send Your Playlists to FF1](../ff1/how-it-works/send-playlists-to-ff1.md)** - Preview your playlists on FF1 devices before tokenizing
+Compare self-hosted and managed usage in [Hosted Feed (Feral File)](feed-server.md).

--- a/docs/dp1-protocol/validator.md
+++ b/docs/dp1-protocol/validator.md
@@ -1,0 +1,75 @@
+# DP-1 Validator Quickstart
+
+Validation is the fastest way to confirm your integration is on the right track.
+
+This page shows a minimal first run with the open-source DP-1 validator.
+
+- What this is: a practical first trust check for playlist inputs.
+- Why use it: catch payload and signature issues before feed/player debugging.
+- What to do next: validate one playlist now, then align schema details.
+
+## Version note
+
+Canonical DP-1 specification is currently `v1.1.0`.
+
+This quickstart uses a minimal `dpVersion: 1.0.0` payload to match current FF1 CLI output and validator examples.
+
+Use the version your integration emits, and validate it against the canonical spec rules.
+
+Current validator behavior is strongest for structure checks and legacy top-level `signature` verification (`--pubkey`).
+
+Do not assume this CLI verifies full DP-1 `v1.1.0` `signatures[]` chain semantics end-to-end unless confirmed upstream.
+
+## What this is
+
+The DP-1 validator checks playlist shape and signature validity.
+
+## Why use it first
+
+If validation fails, playback and distribution issues usually follow. Validate early before feed or player debugging.
+
+## Minimal first run
+
+1) Save a minimal playlist as `playlist.json`:
+
+```json
+{
+  "dpVersion": "1.0.0",
+  "id": "385f79b6-a45f-4c1c-8080-e93a192adccc",
+  "title": "Minimal DP-1 Playlist",
+  "created": "2025-10-17T07:02:03Z",
+  "items": [
+    {
+      "id": "item-1",
+      "title": "Example Item",
+      "source": "https://example.com/artwork.html",
+      "duration": 30,
+      "license": "open"
+    }
+  ]
+}
+```
+
+2) Validate from base64 payload:
+
+```bash
+PLAYLIST_B64="$(cat playlist.json | base64 | tr -d '\n')"
+dp1-validator playlist --playlist "$PLAYLIST_B64"
+```
+
+If your flow includes a legacy top-level `signature`, pass `--pubkey` with the expected Ed25519 public key.
+
+## Canonical validator source
+
+- Validator repository: <https://github.com/display-protocol/dp1-validator>
+
+## Common failure points
+
+- Wrong `dpVersion` for your toolchain.
+- Missing required fields such as `title`, `items`, or item `source`.
+- Signature mismatch caused by payload changes after signing.
+- `signatures[]` chain expectations: verify against canonical DP-1 spec and upstream validator status.
+
+## Next step
+
+Read [Schemas](schemas.md) and align your payload model.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,28 @@
 # Welcome to Feral File Docs
 
-Feral File is a cultural institution and technology company. We make it simple to **live with digital art every day** — through curated exhibitions, open protocols, and dedicated hardware.
+This is the technical documentation for Feral File tools and protocol.
 
-* **Start with FF1** → [Getting Started](ff1/index.md), our art computer that plays digital art on any screen.
-* **Publish & integrate** → [DP-1 Protocol](dp1-protocol/overview.md), an open standard for sharing playlists of digital art.
-* **Explore exhibitions & data** → [Exhibitions & Archive](exhibitions-n-archive/exhibition-structure.md), our model for artworks, metadata, and APIs.
+- What this is: docs for FF1 workflows, DP-1 integration, and supporting API/agent usage.
+- Why use it: get from setup to trusted playback quickly.
+- What to do next: choose one start path below.
 
-Need something not yet public? Email [support@feralfile.com](mailto:support@feralfile.com).
+Canonical protocol truth for DP-1 lives in `display-protocol/dp1` (current spec `v1.1.0`).
 
+## Choose your start
+
+- **I want to build playlists and play them on FF1**
+  - Start with [FF1 CLI: Start Here](api-reference/cli.md)
+- **I want to integrate DP-1 into my own systems**
+  - Start with [DP-1: Start Here (Integrators)](dp1-protocol/overview.md)
+- **I am setting up LLM tools**
+  - Start with [LLM & Agents Quickstart](llm-agents/quickstart.md)
+
+## Product map
+
+- **FF1** is the art computer and reference hardware.
+- **DP-1** is the open, vendor-neutral protocol.
+- **LLM / Agents** is a support layer that helps you call APIs and tools; it does not replace FF1 CLI or DP-1 docs.
+
+## Next step
+
+Open one start page above and complete the first success flow.

--- a/docs/llm-agents/quickstart.md
+++ b/docs/llm-agents/quickstart.md
@@ -1,199 +1,39 @@
-# LLM & Agents – Quickstart
+# LLM & Agents Quickstart
 
-## Introduction
+This section is for teams building LLM or agent tooling around Feral File APIs.
 
-This guide explains how to set up a Large Language Model (LLM) that can call APIs to fetch real-time data from **Feralfile**. The goal is to enable your AI agent to answer questions based on live data from exhibitions, series, and artworks.
+It is a support layer, not a separate product track.
 
-### Quick Demo
+- What this is: a thin setup guide for tool-calling with Feral File APIs.
+- Why use it: connect an agent safely without duplicating protocol or CLI logic.
+- What to do next: choose FF1 CLI or DP-1 as your primary execution path.
 
-Try our preconfigured GPT right away: **[Feralfile Data GPT](https://chatgpt.com/g/g-6894c9f2dfec8191a94e3ae0a7fe82dc-feralfile-data)**
+## What this is for
 
----
+- Connect an LLM tool to OpenAPI endpoints.
+- Keep calls deterministic and small.
+- Route execution to the right primary docs path.
 
-## Setup Guide
+## Use these primary paths
 
-### Step 1: Create Custom GPT
+- Playlist generation and playback workflows: [FF1 CLI: Start Here](../api-reference/cli.md)
+- Protocol correctness, schemas, validator, and feeds: [DP-1: Start Here](../dp1-protocol/overview.md)
 
-Start by creating your own GPT instance in ChatGPT.
+## Minimal setup
 
-### Step 2: Configure API Action
+1. Import OpenAPI schema:
+   - `https://feralfile.com/.well-known/openapi.json`
+2. Add system instructions that keep requests scoped and explicit.
+3. Keep request limits small to avoid oversized context and unstable outputs.
+4. Validate generated playlist payloads with [DP-1 Validator Quickstart](../dp1-protocol/validator.md).
 
-Add an action to enable your GPT to call Feralfile APIs directly (no authentication required).
+## Guardrails
 
-### Step 3: Import OpenAPI Schema
+- Do not treat this section as a replacement for CLI docs.
+- Do not duplicate DP-1 schema or feed operation docs in agent prompts.
+- Keep protocol operations in DP-1 pages and command workflows in FF1 CLI pages.
+- Do not claim end-to-end DP-1 `v1.1.0` parity across all tools unless verified in upstream repos.
 
-Use our predefined schema:
+## Next step
 
-```
-https://feralfile.com/.well-known/openapi.json
-```
-
-> **Note:** This schema follows the OpenAPI standard, making it directly compatible with GPT custom actions and describes all available Feralfile API endpoints.
-
-### Step 4: System Instructions
-
-Configure your GPT with system instructions, example:
-
-```markdown
-This LLM can fetch Feralfile data to answer user requests about exhibitions, series, and artworks.
-
-Data Structure:
-
-- An exhibition contains multiple series
-- A series contains multiple artworks
-
-Special Rules:
-
-- Keep API limits small to avoid oversized responses. (1)
-- Follow artwork naming conventions based on settings.maxArtwork. (2)
-```
-
-(1) : [API endpoints and limits](#api-endpoints)
-(2) : [Artwork naming conventions](#artwork-naming-convention)
-
----
-
-## API Endpoints
-
-### Search Exhibitions
-
-Find exhibitions by keyword:
-
-**Endpoint:**
-
-```http
-GET /api/llm/exhibitions?keyword=<name>&sortBy=relevance&limit=2
-```
-
-**Parameters:**
-
-- `keyword`: Search term
-- `sortBy`: `relevance` (recommended)
-- `limit`: **Maximum 2**
-
-> **⚠️ Important:** Keep limit ≤ 2 to prevent context window overflow and parsing errors.
-
-### Get Series in Exhibition
-
-Retrieve series within an exhibition:
-
-**Endpoint:**
-
-```http
-GET /api/llm/series?exhibitionID=<id>&sortBy=displayIndex&sortOrder=ASC&limit=5&offset=0
-```
-
-**Parameters:**
-
-- `exhibitionID`: Exhibition UUID
-- `sortBy`: `displayIndex`
-- `sortOrder`: `ASC`
-- `limit`: **Maximum 5**
-- `offset`: Pagination offset
-
-> **⚠️ Important:** Keep limit ≤ 5 to prevent context window overflow and parsing errors.
-
-### Get Artworks in Series
-
-Retrieve artworks within a series:
-
-**Endpoint:**
-
-```http
-GET /api/artworks?seriesID=<id>&limit=20&offset=0&sortBy=index&sortOrder=ASC
-```
-
-**Parameters:**
-
-- `seriesID`: Series UUID
-- `limit`: **Maximum 20**
-- `offset`: Pagination offset
-- `sortBy`: `index`
-- `sortOrder`: `ASC`
-
-> **⚠️ Important:** Keep limit ≤ 20 to prevent context window overflow and parsing errors.
-
----
-
-## Special Rules
-
-### Artwork Naming Convention
-
-The artwork naming follows specific logic based on `settings.maxArtwork`:
-
-- **If `settings.maxArtwork = 1`:**
-  Artwork name = `series.title`
-
-- **Otherwise:**
-  Artwork name = `series.title + " " + artwork.name`
-
-### Data Limits (Mandatory)
-
-Always respect these limits to ensure smooth operation. [Learn more about API endpoints](#api-endpoints):
-
-| Endpoint    | Maximum Limit | Reason                                                    |
-| ----------- | ------------- | --------------------------------------------------------- |
-| Exhibitions | 2             | Prevents context overflow                                 |
-| Series      | 5             | Prevents context overflow                                 |
-| Artworks    | 20            | Prevents context overflow and optimal parsing performance |
-
----
-
-## Example Usage
-
-### Prompt
-
-```
-Show me the name of the newest exhibition on Feralfile
-```
-
-### GPT Function Call
-
-```json
-{
-  "domain": "feralfile.com",
-  "method": "get",
-  "path": "/api/llm/exhibitions",
-  "operation": "getExhibitionList",
-  "operation_hash": "a387f38a2b8a40df3263c75d3e1d22e697233c6c",
-  "is_consequential": false,
-  "params": {
-    "limit": 1,
-    "offset": 0,
-    "sortBy": "openAt",
-    "sortOrder": "DESC"
-  }
-}
-```
-
-### API Response (truncated)
-
-```json
-{
-  "response_data": {
-    "result": [
-      {
-        "id": "96a205cc-3e5c-46a7-9662-478dbec8209d",
-        "title": "Net Evil",
-        "slug": "net-evil-das",
-        "exhibitionStartAt": "2025-08-26T16:00:00Z",
-        "previewDuration": 0,
-        "curatorAlumniAccountID": "d900e15b-2510-42f5-b832-18f9ffe46471",
-        "setReservation": 0,
-        "noteTitle": "Dark Patterns",
-        "noteBrief": "<p>In Net Evil, seven artists use the seven deadly sins to explore how evil inhabits the internet. By reflecting how the web enables misdeeds, each work reveals how the occurrence of nefarious behavior on the internet is not a new phenomenon, but part of a long history of human indecency.</p>",
-        "note": "",
-        "coverURI": "exhibition-thumbnails/96a205cc-3e5c-46a7-9662-478dbec8209d/1755593015",
-        "highlightOrder": 10000,
-        (etc),
-      }
-    ]
-  }
-}
-```
-
-### GPT Response
-
-```
-The newest exhibition on Feralfile is "Net Evil", curated by Mackenzie Davenport.
-```
+Choose your execution path: [FF1 CLI first run](../api-reference/cli.md) or [DP-1 integrator start](../dp1-protocol/overview.md).

--- a/docs/llm-agents/safety-licensing.md
+++ b/docs/llm-agents/safety-licensing.md
@@ -1,3 +1,9 @@
 # Safety & Licensing Checks
 
-Coming soon
+This path is kept for link continuity.
+
+Current safety and scope guidance for agent workflows is maintained in the main quickstart.
+
+## Next step
+
+Open [LLM & Agents Quickstart](quickstart.md).

--- a/docs/llm-agents/tool-specs.md
+++ b/docs/llm-agents/tool-specs.md
@@ -1,9 +1,9 @@
 # Tool Specs
 
-Coming soon
+This path is kept for link continuity.
 
-## OpenAI
+Use the active guide for LLM tool-calling scope, guardrails, and live integration links.
 
-## Anthropic
+## Next step
 
-## Gemini
+Open [LLM & Agents Quickstart](quickstart.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,8 @@ extra_css:
   - https://unpkg.com/mermaid@10.6.1/dist/mermaid.min.css
 nav:
   - Home: index.md
+  - FF1 CLI:
+    - Start Here: api-reference/cli.md
   - FF1:
     - Getting Started: ff1/index.md
     - How It Works:
@@ -29,22 +31,19 @@ nav:
     - Install & Basics: artwork-lib/install-basics.md
     - Event Listeners: artwork-lib/event-listeners.md
   - DP-1 Protocol:
-    - Overview: dp1-protocol/overview.md 
-    - Schemas: dp1-protocol/schemas.md 
+    - Start Here (Integrators): dp1-protocol/overview.md
+    - Validator Quickstart: dp1-protocol/validator.md
+    - Schemas: dp1-protocol/schemas.md
     - Feed Server:
-      - Overview: dp1-protocol/feed-server.md 
-      - Run your own Feed Server: dp1-protocol/self-hosted-feed.md 
-    - Player Behavior: dp1-protocol/player-behavior.md 
-    - FF1 Integration: dp1-protocol/ff1-integration.md 
+      - Hosted Feed (Feral File): dp1-protocol/feed-server.md
+      - Run your own Feed Server: dp1-protocol/self-hosted-feed.md
+    - FF1 Playback Bridge: dp1-protocol/ff1-integration.md
+    - Player Behavior: dp1-protocol/player-behavior.md
   - API Reference:
-    - FF1 CLI: api-reference/cli.md
     - Command API: api-reference/command-api.md
     - Webhooks: api-reference/webhooks.md
-    - Auth & Rate-Limits: api-reference/auth-rate-limits.md
   - LLM & Agents:
     - Quickstart: llm-agents/quickstart.md
-    - Tool Specs: llm-agents/tool-specs.md
-    - Safety & Licensing Checks: llm-agents/safety-licensing.md
   - Architecture:
     - Overview: bands/overview.md
   - Changelog: changelog.md


### PR DESCRIPTION
## Summary
- tighten the guided first-run paths for FF1 CLI and DP-1 integrators while keeping existing URLs stable
- align version and compatibility language with upstream truth (DP-1 canonical v1.1.0 + transitional 1.0.x tooling behavior)
- replace de-nav placeholder pages with redirect-style continuity stubs and keep LLM/Agents as a thin support layer

## Validation
- ran `python -m mkdocs build --strict` in this repo
- checked internal links on all touched primary pages