### PR TITLE
docs(llm-agents): link FF1 OpenClaw skill prompt

### DIFF
--- a/docs/api-reference/cli.md
+++ b/docs/api-reference/cli.md
@@ -129,6 +129,7 @@ ff1 send playlist.json
 - Configuration reference: <https://github.com/feral-file/ff1-cli/blob/main/docs/CONFIGURATION.md>
 - Function-calling details: <https://github.com/feral-file/ff1-cli/blob/main/docs/FUNCTION_CALLING.md>
 - More examples: <https://github.com/feral-file/ff1-cli/blob/main/docs/EXAMPLES.md>
+- OpenClaw FF1 skill prompt: <https://github.com/feral-file/ff1-cli/blob/main/examples/openclaw-ff1-skill.md>
 - DP-1 protocol spec: <https://github.com/display-protocol/dp1/blob/main/core/v1.1.0/spec.md>
 - DP-1 validator behavior: <https://github.com/display-protocol/dp1-validator>
 

--- a/docs/llm-agents/quickstart.md
+++ b/docs/llm-agents/quickstart.md
@@ -27,6 +27,12 @@ It is a support layer, not a separate product track.
 3. Keep request limits small to avoid oversized context and unstable outputs.
 4. Validate generated playlist payloads with [DP-1 Validator Quickstart](../dp1-protocol/validator.md).
 
+If your agent should run FF1 CLI directly, use this ready prompt as your starting point:
+
+- <https://github.com/feral-file/ff1-cli/blob/main/examples/openclaw-ff1-skill.md>
+
+This keeps the flow simple: status -> config validate -> build -> validate -> send/publish, and reports failing command + code when a step breaks.
+
 ## Guardrails
 
 - Do not treat this section as a replacement for CLI docs.


### PR DESCRIPTION
## Summary
- Link to the FF1 OpenClaw skill prompt from agent quickstart and FF1 CLI start page.
- Keep docs minimal and avoid adding new sections/sprawl.

## Companion PR (Required)
This change is paired with an ff1-cli update and should be merged together.

- ff1-cli PR: https://github.com/feral-file/ff1-cli/pull/29
- docs-public PR: https://github.com/feral-file/docs/pull/152

## Merge checklist
- [ ] Reviewed ff1-cli changes
- [ ] Reviewed docs-public changes
- [ ] Merging both PRs together

## Files changed
- `docs/llm-agents/quickstart.md`
- `docs/api-reference/cli.md`

## Validation
- `mkdocs build --strict`