### PR TITLE
docs: point FF1 mobile docs to the canonical app repo

### DIFF
--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -1,5 +1,6 @@
 # Contributing
 
 1. Fork this repo.
-2. For FF1 hardware or OS changes, open PRs in `ff1-docs` first, then bump the submodule here.
-3. Label PRs with `band-5`, `band-6`, or `band-7` so we can route reviews quickly.
+2. For mobile app code or mobile-app documentation source changes, open PRs in [feral-file/ff-app](https://github.com/feral-file/ff-app).
+3. For FF1 hardware or OS changes, open PRs in `ff1-docs` first, then bump the submodule here.
+4. Label PRs with `band-5`, `band-6`, or `band-7` so we can route reviews quickly.

--- a/docs/ff1/how-it-works/display.md
+++ b/docs/ff1/how-it-works/display.md
@@ -13,7 +13,7 @@ The FF1 ecosystem enables users to create and display artwork playlists through 
 ## Architecture Components
 
 ### Core Services
-- **Mobile App** (`feralfile-app`) - Flutter-based mobile controller
+- **Mobile App** ([`ff-app`](https://github.com/feral-file/ff-app)) - Canonical Flutter-based FF1 and Digital Art System mobile controller
 - **Command API** (`ff-cloud-command-service`) - AI-powered command processing service  
 - **DP1 Feed Server** (`dp1-feed`) - Playlist storage and distribution
 - **Relayer** (`ff1-relayer`) - WebSocket bridge between mobile and device

--- a/docs/ff1/index.md
+++ b/docs/ff1/index.md
@@ -59,6 +59,8 @@ You do **not** need to install the app ahead of time — scanning the QR code wi
 - **Android:** <https://play.google.com/store/apps/details?id=com.feralfile.app>  
 - **iPhone:** <https://apps.apple.com/us/app/feral-file-controller/id6755812386>
 
+For development, source access, or contribution to the mobile controller, use the canonical public repo: [feral-file/ff-app](https://github.com/feral-file/ff-app).
+
 ---
 
 ## Step 3 (Advanced): Reinstall FF OS from USB


### PR DESCRIPTION
## Problem
Some FF1 documentation still referred to the old mobile app repo name and did not clearly point contributors to the canonical public Flutter app repository.

## Why it matters
Public docs should send readers and contributors to the correct source of truth for the mobile controller so repo discovery and contribution paths stay consistent.

## Acceptance checks
- FF1 architecture docs name `feral-file/ff-app` as the canonical mobile app repo
- Getting Started points developers to the public app repo
- Contributing guidance routes mobile app changes to `feral-file/ff-app`