### PR TITLE
Use @feralfile/cli as the npm install name across the docs site

### DIFF
--- a/docs/api-reference/cli.md
+++ b/docs/api-reference/cli.md
@@ -24,7 +24,7 @@ This path uses the canonical commands from `feral-file/ff-cli`.
 
 ```bash
 # 1) Install (shortest path)
-npm i -g ff-cli
+npm i -g @feralfile/cli
 
 # 2) Run guided setup
 ff-cli setup
@@ -45,7 +45,7 @@ You are successful when the playlist builds and plays on your configured Art Com
 ### Primary
 
 ```bash
-npm i -g ff-cli
+npm i -g @feralfile/cli
 ```
 
 ### Alternate: prebuilt binary installer
@@ -57,8 +57,8 @@ curl -fsSL https://feralfile.com/ff-cli-install | bash
 ### Alternate: one-off with npx
 
 ```bash
-npx ff-cli setup
-npx ff-cli chat
+npx @feralfile/cli setup
+npx @feralfile/cli chat
 ```
 
 ### Manual configuration path (advanced)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -152,7 +152,7 @@ The work count in the Me section now shows the correct number while scrolling.
 
 **FF1 is more secure by default**
 
-SSH access via username and password is now disabled. If you need to connect to FF1 directly—for development or debugging—use [ff1-cli](https://github.com/feral-file/ff1-cli) to connect instead.
+SSH access via username and password is now disabled. If you need to connect to FF1 directly—for development or debugging—use [ff1-cli](https://github.com/feral-file/ff-cli) to connect instead.
 
 **Videos that were cutting off early now play their full length**
 
@@ -536,7 +536,7 @@ We've paused visibility for most Objkt playlists in the mobile app while rebuild
 
 **Prompt-to-Playlist Tool**
 
-We've published [ff1-cli](https://github.com/feral-file/ff1-cli), an open-source command-line tool that turns prompts into DP-1 playlists. Type a phrase, generate a playlist, and play it on your FF1—no web UI required. See the [ff1-cli documentation](https://docs.feralfile.com/api-reference/cli/).
+We've published [ff1-cli](https://github.com/feral-file/ff-cli), an open-source command-line tool that turns prompts into DP-1 playlists. Type a phrase, generate a playlist, and play it on your FF1—no web UI required. See the [ff1-cli documentation](https://docs.feralfile.com/api-reference/cli/).
 
 **OTA Security Update**
 


### PR DESCRIPTION
The rename pass in #163 (FF1 → Art Computer, ff1-cli → ff-cli) landed before the CLI's npm package got scoped under the feralfile org. As of the [ff-cli v1.1.4 release](https://github.com/feral-file/ff-cli/releases/tag/1.1.4), the published package is **@feralfile/cli** — the unscoped \`ff-cli\` name on npm is owned by an unrelated project. Right now docs.feralfile.com tells users to \`npm i -g ff-cli\`, which would install the wrong thing.

## Changes

- **\`docs/api-reference/cli.md\`** — \`npm i -g ff-cli\` → \`npm i -g @feralfile/cli\` (2 spots), \`npx ff-cli ...\` → \`npx @feralfile/cli ...\` (2 spots). CLI binary invocations (\`ff-cli setup\`, \`ff-cli chat\`, etc.) are unchanged — the on-PATH binary is still \`ff-cli\`.
- **\`docs/changelog.md\`** — two historical entries linked to the old \`github.com/feral-file/ff1-cli\` repo URL; updated to point at the current canonical repo (\`feral-file/ff-cli\`). Display text \`ff1-cli\` kept as historical record.

## Not changed

- The prebuilt-binary installer URL (\`https://feralfile.com/ff-cli-install | bash\`) is left as-is — that's the installer-script endpoint, not an npm command.

## Test plan

- [ ] Preview build of the site renders the install snippets correctly
- [ ] \`npm i -g @feralfile/cli\` from a fresh shell actually installs the package (sanity check)